### PR TITLE
Support installer-paths nested into wordpress-install-dir

### DIFF
--- a/src/johnpbloch/Composer/WordPressCoreInstaller.php
+++ b/src/johnpbloch/Composer/WordPressCoreInstaller.php
@@ -8,17 +8,15 @@ use Composer\Package\PackageInterface;
 class WordPressCoreInstaller extends LibraryInstaller {
 
 	const TYPE = 'wordpress-core';
+	const DEFAULT_INSTALL_DIR = 'wordpress';
 
 	private static $_installedPaths = array();
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public function getInstallPath( PackageInterface $package ) {
+	public static function extractInstallDir(PackageInterface $package, PackageInterface $root = null) {
 		$installationDir = false;
 		$prettyName      = $package->getPrettyName();
-		if ( $this->composer->getPackage() ) {
-			$topExtra = $this->composer->getPackage()->getExtra();
+		if ( $root ) {
+			$topExtra = $root->getExtra();
 			if ( ! empty( $topExtra['wordpress-install-dir'] ) ) {
 				$installationDir = $topExtra['wordpress-install-dir'];
 				if ( is_array( $installationDir ) ) {
@@ -31,15 +29,23 @@ class WordPressCoreInstaller extends LibraryInstaller {
 			$installationDir = $extra['wordpress-install-dir'];
 		}
 		if ( ! $installationDir ) {
-			$installationDir = 'wordpress';
+			$installationDir = self::DEFAULT_INSTALL_DIR;
 		}
+		return $installationDir;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getInstallPath( PackageInterface $package ) {
+		$installationDir = self::extractInstallDir($package, $this->composer->getPackage());
 		if (
 			! empty( self::$_installedPaths[$installationDir] ) &&
-			$prettyName !== self::$_installedPaths[$installationDir]
+			$package->getPrettyName() !== self::$_installedPaths[$installationDir]
 		) {
 			throw new \InvalidArgumentException( 'Two packages cannot share the same directory!' );
 		}
-		self::$_installedPaths[$installationDir] = $prettyName;
+		self::$_installedPaths[$installationDir] = $package->getPrettyName();
 		return $installationDir;
 	}
 

--- a/src/johnpbloch/Composer/WordPressCorePlugin.php
+++ b/src/johnpbloch/Composer/WordPressCorePlugin.php
@@ -3,10 +3,21 @@
 namespace johnpbloch\Composer;
 
 use Composer\Composer;
+use Composer\DependencyResolver\Operation\InstallOperation;
+use Composer\EventDispatcher\EventSubscriberInterface;
+use Composer\Factory;
+use Composer\Installer;
+use Composer\Installer\PackageEvent;
+use Composer\Installer\PackageEvents;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
+use Composer\Repository\InstalledArrayRepository;
 
-class WordPressCorePlugin implements PluginInterface {
+class WordPressCorePlugin implements EventSubscriberInterface, PluginInterface {
+
+	protected $composer;
+	protected $io;
+	protected $runInstallAgain = false;
 
 	/**
 	 * Apply plugin modifications to composer
@@ -15,8 +26,119 @@ class WordPressCorePlugin implements PluginInterface {
 	 * @param IOInterface $io
 	 */
 	public function activate( Composer $composer, IOInterface $io ) {
+		$this->composer = $composer;
+		$this->io = $io;
 		$installer = new WordPressCoreInstaller( $io, $composer );
 		$composer->getInstallationManager()->addInstaller( $installer );
 	}
 
+	public static function getSubscribedEvents() {
+		return array(
+			PackageEvents::POST_PACKAGE_INSTALL => 'onPostPackageInstallOrUpdate',
+			PackageEvents::POST_PACKAGE_UPDATE => 'onPostPackageInstallOrUpdate',
+		);
+	}
+
+	public function onPostPackageInstallOrUpdate(PackageEvent $e)
+	{
+		// if the package that's currently getting updated or installed is of type "wordpress-core", then we must re-install themes and plugins if they're supposed to get installed into a subdir of wordpress itself using composer/installer's "installer-paths" feature
+		$thisOperation = $e->getOperation();
+		if ($thisOperation->getJobType() == 'update') {
+			$thisPackage = $thisOperation->getTargetPackage();
+		} elseif ($thisOperation->getJobType() == 'install') {
+			// regular installs also matter if a theme or plugin package name is alphabetically "smaller" than "johnpbloch/wordpress" (or whatever the name is), then it'd get installed first and overwritten
+			$thisPackage = $thisOperation->getPackage();
+		} else {
+			return;
+		}
+		// we're only interested in installs or updates of WordPress itself
+		if ($thisPackage->getType() != 'wordpress-core') {
+			return;
+		}
+		
+		$root = $this->composer->getPackage();
+		$wpInstallationDir = rtrim(WordPressCoreInstaller::extractInstallDir($thisPackage, $root), '/\\');
+		
+		$extra = $root->getExtra();
+		// we only have to do anything in one case:
+		// if the installer path for anything is a subdirectory of wordpress itself
+		// e.g. this:
+		// "extra": {
+		//   "wordpress-install-dir": "wordpress",
+		//   "installer-paths": {
+		//     "wordpress/wp-content/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
+		//     "wordpress/wp-content/plugins/{$name}/": ["type:wordpress-plugin"],
+		//     "wordpress/wp-content/themes/{$name}/": ["type:wordpress-theme"]
+		//   }
+		// },
+		$nestedPackages = array();
+		$nestedTypes = array();
+		$nestedVendors = array();
+		if (isset($extra['installer-paths']) && is_array($extra['installer-paths'])) {
+			foreach ($extra['installer-paths'] as $path => $instructions) {
+				if (strpos($path, "$wpInstallationDir/") !== 0 && strpos($path, "$wpInstallationDir\\") !== 0) {
+					continue;
+				}
+				foreach ((array)$instructions as $instruction) {
+					// each array entry can be a package name, or a "type:...", or a "vendor:..."
+					if (strpos($instruction, 'type:') === 0) {
+						$nestedTypes[] = substr($instruction, 5);
+					} elseif (strpos($instruction, 'vendor:') === 0) {
+						$nestedVendors[] = substr($instruction, 7);
+					} else {
+						$nestedPackages[] = $instruction;
+					}
+				}
+			}
+		}
+		
+		if (!$nestedPackages && !$nestedTypes && !$nestedVendors) {
+			return;
+		}
+		
+		$im = $this->composer->getInstallationManager();
+		$repo = $e->getInstalledRepo();
+		
+		// reverse over list of install steps to put the ones that Composer would install after wordpress-core anyway on an ignore list
+		$ignore = array();
+		foreach (array_reverse($e->getOperations()) as $otherOperation) {
+			if ($otherOperation == $thisOperation) {
+				// any operation after the install/update of this package (so any before in the reversed array) we do not want to duplicate
+				// otherwise, the second install might cause an error because the package is already there, e.g. if it's from a path repo and got symlinked
+				break;
+			}
+			if ($otherOperation->getJobType() == 'install') {
+				$ignore[] = $otherOperation->getPackage()->getPrettyName();
+			} elseif ($otherOperation->getJobType() == 'update') {
+				$ignore[] = $otherOperation->getTargetPackage()->getPrettyName();
+			}
+		}
+		
+		$needsInstall = array();
+		foreach ($e->getRequest()->getJobs() as $job) {
+			if (!isset($job['packageName'])) {
+				continue;
+			}
+			$package = $repo->findPackage($job['packageName'], $job['constraint']);
+			if (!$package || in_array($package->getPrettyName(), $ignore)) {
+				continue;
+			}
+			if (
+				in_array($package->getPrettyName(), $nestedPackages) || 
+				in_array($package->getType(), $nestedTypes) || 
+				in_array(explode('/', $package->getPrettyName(), 2)[0], $nestedVendors)
+			) {
+				$needsInstall[] = $package;
+			}
+		}
+		
+		$repo = new InstalledArrayRepository(array());
+		foreach ($needsInstall as $package) {
+			$im->install($repo, new InstallOperation($package, $thisOperation->getReason())); // re-use reason from wordpress-core install/update operation
+			if ($this->io->isVeryVerbose()) {
+				$this->io->writeError('    REASON: nested inside installed or updated '.$thisPackage->getPrettyName());
+				$this->io->writeError('');
+			}
+		}
+	}
 }


### PR DESCRIPTION
This allows an `installer-paths` entry for WordPress themes or plugins to be a subdirectory of `wordpress-install-dir`, which is nice, because it means no messing with `WP_CONTENT_DIR` and `WP_CONTENT_URL` is necessary:

```json
"extra": {
	"wordpress-install-dir": "wordpress",
	"installer-paths": {
		"wordpress/wp-content/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
		"wordpress/wp-content/plugins/{$name}/": ["type:wordpress-plugin"],
		"wordpress/wp-content/themes/{$name}/": ["type:wordpress-theme"]
	}
}
```

Without this change, running `composer update` to get a new version of `johnpbloch/wordpress` updates only that package, a process which wipes the whole `wordpress/` directory, and, with that, the `wp-content/themes/' and 'wp-content/plugins/' directories that contain dependencies installed using Composer, so an additional 'composer install' is necessary to bring them back:

```ShellSession
$ composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Updating johnpbloch/wordpress (4.7.1 => 4.7.2) Loading from cache
Writing lock file
Generating autoload files
$ composer install
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Package operations: 4 installs, 0 updates, 0 removals
  - Installing dzuelke/twentyfifteen-child (1.0.11) Symlinked from themes/twentyfifteen-child
  - Installing wpackagist-plugin/amazon-s3-and-cloudfront (0.9.12) Loading from cache
  - Installing wpackagist-plugin/amazon-web-services (0.3.7) Loading from cache
  - Installing wpackagist-plugin/sendgrid-email-delivery-simplified (1.10.7) Loading from cache
Generating autoload files
```

Furthermore, it may happen that a plugin or theme is "alphabetically smaller" than "johnpbloch/wordpress", in which case a `composer install` from the lock file would result in such a package getting installed first, and then get overwritten because the `wordpress/` folder gets replaced entirely:

```ShellSession
$ composer install
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Package operations: 5 installs, 0 updates, 0 removals
  - Installing dzuelke/twentyfifteen-child (1.0.11) Symlinked from themes/twentyfifteen-child
  - Installing johnpbloch/wordpress (4.7.2) Loading from cache
  - Installing wpackagist-plugin/amazon-s3-and-cloudfront (0.9.12) Loading from cache
  - Installing wpackagist-plugin/amazon-web-services (0.3.7) Loading from cache
  - Installing wpackagist-plugin/sendgrid-email-delivery-simplified (1.10.7) Loading from cache
Generating autoload files
$ composer install
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Package operations: 1 install, 0 updates, 0 removals
  - Installing dzuelke/twentyfifteen-child (1.0.11) Symlinked from themes/twentyfifteen-child
Generating autoload files
```

The event handler fixes both cases, and supports all three `composer/installers` mapping types for `installer-paths` (literal package names, `type:` prefix, and `vendor:` prefix).