### PR TITLE
Updated package name in custom path example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The root composer package can also declare custom paths as an object keyed by pa
 "extra": {
 	"wordpress-install-dir": {
 		"wordpress/wordpress": "wordpress",
-		"johnpbloch/wordpress": "jpb-wordpress"
+		"johnpbloch/wordpress-core": "jpb-wordpress"
 	}
 }
 ```


### PR DESCRIPTION
`johnpbloch/wordpress` package is no longer of `wordpress-core` type itself.

This bit me while changing some things, since it ignored copy-pasted custom path and proceeded to nuke default `wordpress` folder in the project. :)