### PR TITLE
Fix test failures in Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 phpunit.xml
 clover.xml
 .phpunit.result.cache
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 vendor
 phpunit.xml
 clover.xml
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
   - '7.0'
   - '7.1'
   - '7.2'
+  - '7.3'
 before_script:
   - composer update
 script: composer test

--- a/tests/phpunit/WordPressCoreInstallerTest.php
+++ b/tests/phpunit/WordPressCoreInstallerTest.php
@@ -128,7 +128,7 @@ class WordPressCoreInstallerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider                   dataProviderSensitiveDirectories
+	 * @dataProvider dataProviderSensitiveDirectories
 	 */
 	public function testSensitiveInstallDirectoriesNotAllowed( $directory ) {
 		$this->expectException( '\InvalidArgumentException' );

--- a/tests/phpunit/WordPressCoreInstallerTest.php
+++ b/tests/phpunit/WordPressCoreInstallerTest.php
@@ -115,11 +115,9 @@ class WordPressCoreInstallerTest extends TestCase {
 		$this->assertEquals( 'wp', $installer->getInstallPath( $package ) );
 	}
 
-	/**
-	 * @expectedException \InvalidArgumentException
-	 * @expectedExceptionMessage Two packages (test/bazbat and test/foobar) cannot share the same directory!
-	 */
 	public function testTwoPackagesCannotShareDirectory() {
+		$this->expectException( '\InvalidArgumentException' );
+		$this->expectExceptionMessage( 'Two packages (test/bazbat and test/foobar) cannot share the same directory!' );
 		$composer  = $this->createComposer();
 		$installer = new WordPressCoreInstaller( new NullIO(), $composer );
 		$package1  = new Package( 'test/foobar', '1.1.1.1', '1.1.1.1' );
@@ -131,10 +129,10 @@ class WordPressCoreInstallerTest extends TestCase {
 
 	/**
 	 * @dataProvider                   dataProviderSensitiveDirectories
-	 * @expectedException \InvalidArgumentException
-	 * @expectedExceptionMessageRegExp /Warning! .+? is an invalid WordPress install directory \(from test\/package\)!/
 	 */
 	public function testSensitiveInstallDirectoriesNotAllowed( $directory ) {
+		$this->expectException( '\InvalidArgumentException' );
+		$this->expectExceptionMessageRegExp( '/Warning! .+? is an invalid WordPress install directory \(from test\/package\)!/' );
 		$composer  = $this->createComposer();
 		$installer = new WordPressCoreInstaller( new NullIO(), $composer );
 		$package   = new Package( 'test/package', '1.1.0.0', '1.1' );

--- a/tests/phpunit/WordPressCoreInstallerTest.php
+++ b/tests/phpunit/WordPressCoreInstallerTest.php
@@ -116,8 +116,10 @@ class WordPressCoreInstallerTest extends TestCase {
 	}
 
 	public function testTwoPackagesCannotShareDirectory() {
-		$this->expectException( '\InvalidArgumentException' );
-		$this->expectExceptionMessage( 'Two packages (test/bazbat and test/foobar) cannot share the same directory!' );
+		$this->jpbExpectException(
+			'\InvalidArgumentException',
+			'Two packages (test/bazbat and test/foobar) cannot share the same directory!'
+		);
 		$composer  = $this->createComposer();
 		$installer = new WordPressCoreInstaller( new NullIO(), $composer );
 		$package1  = new Package( 'test/foobar', '1.1.1.1', '1.1.1.1' );
@@ -131,8 +133,11 @@ class WordPressCoreInstallerTest extends TestCase {
 	 * @dataProvider dataProviderSensitiveDirectories
 	 */
 	public function testSensitiveInstallDirectoriesNotAllowed( $directory ) {
-		$this->expectException( '\InvalidArgumentException' );
-		$this->expectExceptionMessageRegExp( '/Warning! .+? is an invalid WordPress install directory \(from test\/package\)!/' );
+		$this->jpbExpectException(
+			'\InvalidArgumentException',
+			'/Warning! .+? is an invalid WordPress install directory \(from test\/package\)!/',
+			true
+		);
 		$composer  = $this->createComposer();
 		$installer = new WordPressCoreInstaller( new NullIO(), $composer );
 		$package   = new Package( 'test/package', '1.1.0.0', '1.1' );
@@ -165,6 +170,19 @@ class WordPressCoreInstallerTest extends TestCase {
 		$composer->setConfig( new Config() );
 
 		return $composer;
+	}
+
+	private function jpbExpectException( $class, $message = '', $isRegExp = false ) {
+		if ( method_exists( $this, 'expectException' ) ) {
+			$this->expectException($class);
+			if ( $message ) {
+				$isRegExp || $this->expectExceptionMessage( $message );
+				$isRegExp && $this->expectExceptionMessageRegExp( $message );
+			}
+		} else {
+			$isRegExp || $this->setExpectedException( $class, $message );
+			$isRegExp && $this->setExpectedExceptionRegExp( $class, $message );
+		}
 	}
 
 }

--- a/tests/phpunit/WordPressCoreInstallerTest.php
+++ b/tests/phpunit/WordPressCoreInstallerTest.php
@@ -148,7 +148,7 @@ class WordPressCoreInstallerTest extends TestCase {
 	}
 
 	/**
-	 * @beforeClass
+	 * @before
 	 * @afterClass
 	 */
 	public static function resetInstallPaths() {

--- a/tests/phpunit/WordPressCoreInstallerTest.php
+++ b/tests/phpunit/WordPressCoreInstallerTest.php
@@ -31,14 +31,6 @@ use PHPUnit\Framework\TestCase;
 
 class WordPressCoreInstallerTest extends TestCase {
 
-	protected function setUp() {
-		$this->resetInstallPaths();
-	}
-
-	protected function tearDown() {
-		$this->resetInstallPaths();
-	}
-
 	public function testSupports() {
 		$installer = new WordPressCoreInstaller( new NullIO(), $this->createComposer() );
 
@@ -157,7 +149,11 @@ class WordPressCoreInstallerTest extends TestCase {
 		);
 	}
 
-	private function resetInstallPaths() {
+	/**
+	 * @beforeClass
+	 * @afterClass
+	 */
+	public static function resetInstallPaths() {
 		$prop = new \ReflectionProperty( '\johnpbloch\Composer\WordPressCoreInstaller', '_installedPaths' );
 		$prop->setAccessible( true );
 		$prop->setValue( array() );


### PR DESCRIPTION
Now that PhpUnit 8.0 is out, the test classes need to be updated to stop from breaking. I'd also like to add PHP 7.3 to the tested versions.