### PR TITLE
Add support for Composer version 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,10 @@
 		"class": "johnpbloch\\Composer\\WordPressCorePlugin"
 	},
 	"require": {
-		"composer-plugin-api": "^1.0"
+		"composer-plugin-api": "^1.0 || ^2.0"
 	},
 	"require-dev": {
-		"composer/composer": "^1.0",
+		"composer/composer": "^1.0 || ^2.0",
 		"phpunit/phpunit": ">=4.8.35"
 	},
 	"conflict": {

--- a/src/johnpbloch/Composer/WordPressCorePlugin.php
+++ b/src/johnpbloch/Composer/WordPressCorePlugin.php
@@ -38,4 +38,16 @@ class WordPressCorePlugin implements PluginInterface {
 		$composer->getInstallationManager()->addInstaller( $installer );
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
+	public function deactivate( Composer $composer, IOInterface $io ) {
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function uninstall( Composer $composer, IOInterface $io ) {
+	}
+
 }


### PR DESCRIPTION
Hi John,

Composer version 2 has `composer-plugin-api` version 2. This PR updates the version constraint to `^1 || ^2` so we can support both composer versions.

See [What's new in Composer 2](https://php.watch/articles/composer-2) and [UPGRADE-2.0](https://github.com/composer/composer/blob/master/UPGRADE-2.0.md#for-integrators-and-plugin-authors) for more changes in API. Empty methods `\johnpbloch\Composer\WordPressCorePlugin::deactivate()` and `\johnpbloch\Composer\WordPressCorePlugin::uninstall()` are added to make it compatible both versions.

Related: composer/composer#8726

Thank you. 