### PR TITLE
Make it work with Composer v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
 		}
 	},
 	"extra": {
-		"class": "johnpbloch\\Composer\\WordPressCorePlugin"
+		"class": "johnpbloch\\Composer\\WordPressCorePlugin",
+		"plugin-modifies-downloads": true
 	},
 	"require": {
 		"composer-plugin-api": "^1.0 || ^2.0",


### PR DESCRIPTION
This runs wordpress-core-installer plugin before other packages are installed.

Please see https://getcomposer.org/doc/articles/plugins.md#plugin-modifies-downloads

Fixes #29 